### PR TITLE
Update main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -657,7 +657,7 @@ func main() {
 	}
 
 	PrintInfos( "", fmt.Sprintf("%d searches performed",n_search) )
-	PrintInfos( "", fmt.Sprintf("%d subdomains found",len(t_endpoints)) )
+	PrintInfos( "", fmt.Sprintf("%d endpoints found",len(t_endpoints)) )
 }
 
 


### PR DESCRIPTION
Just fixed a small typo in `main.go` where the tool incorrectly printed "x subdomains found" instead of "x endpoints found" at the end of the run.